### PR TITLE
style(staff-dashboard): made responsive

### DIFF
--- a/frontend/components/organisms/admin-stats-cards.tsx
+++ b/frontend/components/organisms/admin-stats-cards.tsx
@@ -75,12 +75,12 @@ function StatsCard({ icon: Icon, title, value, footer }: StatsCardProps) {
       <div className="flex items-center justify-between">
         <div className="flex items-center">
           <Icon className="me-2 text-primary" />
-          <p className="text-lg tracking-tight">{title}</p>
+          <p className="tracking-tight">{title}</p>
         </div>
         <FaEllipsis className="me-2 opacity-0 lg:opacity-100" />
       </div>
-      <p className="text-3xl font-bold">{value}</p>
-      <p className="flex items-center justify-center md:justify-normal">
+      <p className="text-2xl font-bold">{value}</p>
+      <p className="flex items-center justify-center text-sm md:justify-normal">
         {footer.trend ? (
           <>
             <span
@@ -112,7 +112,7 @@ function StatsCard({ icon: Icon, title, value, footer }: StatsCardProps) {
 
 export default function AdminStatsCards() {
   return (
-    <div className="grid grid-cols-1 place-items-center gap-4 text-card-foreground md:grid-cols-2 lg:grid-cols-4">
+    <div className="grid grid-cols-1 place-items-center gap-4 text-center text-card-foreground md:grid-cols-2 md:text-left xl:grid-cols-4">
       {statsData.map((stat, index) => (
         <StatsCard key={index} {...stat} />
       ))}

--- a/frontend/components/pages/staff-dashboard.tsx
+++ b/frontend/components/pages/staff-dashboard.tsx
@@ -16,8 +16,8 @@ export default function StaffDashboard() {
   const patients = usePatients();
 
   return (
-    <div className="m-6 space-y-4 text-center md:text-left">
-      <div className="mx-2 py-4">
+    <div className="m-6 space-y-4">
+      <div className="mx-2 py-4 text-left">
         <div className="flex flex-row space-x-1 text-2xl font-bold">
           <span>Good Day,</span>
           <span className="text-blue-500">
@@ -32,14 +32,14 @@ export default function StaffDashboard() {
 
       <StatsCard />
 
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3 lg:gap-6">
+      <div className="grid grid-cols-1 items-center gap-4 lg:grid-cols-3 lg:gap-6">
         {/* Visitors chart spans 2 columns */}
         <div className="lg:col-span-2">
           <VisitorsChart />
         </div>
 
         {/* Sidebar spaced out to align bottom */}
-        <div className="flex flex-col justify-between">
+        <div className="flex flex-col justify-between space-y-4">
           <CommonDiseasesChart />
           <CommonMedicinesChart />
         </div>


### PR DESCRIPTION
maybe we can change the "Queued for Assessment" & "Queued for Treatment" to "Assessment & Treatment so its easier to view in mobile.

<img width="753" height="945" alt="Screenshot 2025-11-01 155922" src="https://github.com/user-attachments/assets/a377a924-d3ec-4b4e-a6e4-76266445b297" />

<img width="736" height="943" alt="Screenshot 2025-11-01 160139" src="https://github.com/user-attachments/assets/188f5f77-ec12-48aa-a855-c34841eee7cb" />

<img width="725" height="943" alt="Screenshot 2025-11-01 160153" src="https://github.com/user-attachments/assets/bb160bc6-ebbd-4b66-a684-39d662ba3ecb" />